### PR TITLE
Change passphrase parameters to make link cleaner

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2,8 +2,8 @@ var formdata = new FormData();
 
 const DEFAULT_EXPIRY = 60 * 60; // one hour
 const PASSPHRASE_CHARSET =
-  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz~!@#$%^&*()?";
-const PASSPHRASE_LEN = 64;
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz@#$%^&?";
+const PASSPHRASE_LEN = 40;
 const SALT_LEN = 16;
 const IV_LEN = 16;
 


### PR DESCRIPTION
Make passphrase 40 characters instead of 64 for randomly generated passphrase and remove some characters from dictionary. Still has sufficient entropy