### PR TITLE
display appropriate toast error message based on error

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -122,8 +122,15 @@ function handleRetrieveSubmit(event) {
       });
     })
     .catch((err) => {
-      clearDataOnClick();
-      toastr.error("Invalid", "", { timeOut: 1500 });
+      if (err instanceof DOMException) {
+        console.log(err);
+        clearDataOnClick();
+        toastr.error("Incorrect passphrase", "", { timeOut: 1500 });
+      } else {
+        clearDataOnClick();
+        document.getElementById("secretid").value = "";
+        toastr.error("Invalid url", "", { timeOut: 1500 });
+      }
     });
 }
 
@@ -154,9 +161,6 @@ function fetchSecret(id) {
     .then(function (data) {
       console.log(data);
       return data;
-    })
-    .catch((err) => {
-      console.log(err);
     });
 }
 


### PR DESCRIPTION
- incorrect passphrase displays incorrect passphrase toast message and only passphrase input field is cleared
- invalid secret id will display invalid url toast message and both input fields are cleared
#73
 
(1) incorrect passphrase:
![image](https://user-images.githubusercontent.com/46267622/126547642-85067e4f-8ab4-48be-9600-dadea575cdb5.png)

(2) invalid secret id (invalid url):
![image](https://user-images.githubusercontent.com/46267622/126547715-7d3c78f4-46f7-4c25-91fa-122eb603b8b7.png)

(3) correct passphrase + valid secret id:
![image](https://user-images.githubusercontent.com/46267622/126547829-a337e55c-a914-4393-9e70-87104732fc4c.png)

